### PR TITLE
update direction enum for scene proptypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,9 +41,9 @@ declare namespace RNRF {
      */
     duration?: number,
     /**
-     * direction of animation horizontal/vertical
+     * direction of animation horizontal/vertical/leftToRight
      */
-    direction?: 'vertical' | 'horizontal',
+    direction?: 'vertical' | 'horizontal' | 'leftToRight',
     /**
      * optional if provided overrides the default spring animation
      */


### PR DESCRIPTION
I think the "animation" and "duration" props are identical, such that one should probably be deprecated.